### PR TITLE
Update according to Miro's review

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 importpatches contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ The script adds Git hash IDs to the spec file.
 These are hashes of the patch content, ignoring tings like context lines and
 comments.
 When one of these changes, pay special atttention to the patch diff.
+
+## License
+
+The script is available under the MIT license. May it serve you well.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ conventions.)
 
 ## Setup
 
-Add the script to your `$PATH`.
+Add the script to your `$PATH`, for example:
+
+    ln -s $PWD/importpatches.py ~/.local/bin/importpatches
 
 The script needs to know where your local clone of `fedora-python/cpython` is,
 and uses Git configuration as a default.

--- a/importpatches.py
+++ b/importpatches.py
@@ -297,16 +297,12 @@ def main(spec, repo, tag, head):
             click.secho(f'Assuming --tag={tag}', fg='yellow')
 
         if head == None:
-            with spec.open() as f:
-                for line in f:
-                    if match := RELEASE_RE.match(line):
-                        release = match[1]
-                        break
-                else:
-                    raise click.UsageError(
-                        "Release not found in spec; check " +
-                        "logic in the script or specify --head explicitly."
-                    )
+            release = run(
+                'rpm',
+                '--undefine=dist',
+                '--queryformat=%{release}\n',
+                '--specfile', str(spec),
+            ).stdout.splitlines()[0]
             upstream_version = tag.lstrip('v')
             head = f'fedora-{upstream_version}-{release}'
             click.secho(f'Assuming --head={head}', fg='yellow')

--- a/importpatches.py
+++ b/importpatches.py
@@ -28,7 +28,6 @@ PATCH_SECTION_STARTS = {
 }
 PATCH_SECTION_END = '# (New patches go here ^^^)'
 FLIENAME_SAFE_RE = re.compile('^[a-zA-Z0-9._-]+$')
-RELEASE_RE = re.compile(r'Release: ([0-9]+)%\{\?dist\}')
 
 BUNDLED_VERSION_RE = re.compile('-_([A-Z]+)_VERSION = "([0-9.]+)"')
 BUNDLED_VERSION_BLURB = """

--- a/importpatches.py
+++ b/importpatches.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import subprocess
 from pathlib import Path
 import sys


### PR DESCRIPTION
- Make the script executable, add "installation" command to README
- Add license
- Use the `fedora-X.Y.Z-R` tag as --head

The script doesn't try different `R` in `fedora-X.Y.Z-R`. If the current tag isn't found, it errors out. You can copy the option from `Assuming --head=...`, edit it, and run again.
(The output is so long that a warning wouldn't be visible anyway, unless I made warnings fatal without e.g. `--force`, and at that point explicit `--head` is better.)