### PR TITLE
Avoid defining macros with %{expand:, they might be unterminated on 1 line

### DIFF
--- a/importpatches.py
+++ b/importpatches.py
@@ -313,7 +313,7 @@ def main(spec, repo, base, head, python_version):
                 rpm_globals = []
                 for line in f:
                     line = line.strip()
-                    if line.startswith('%global '):
+                    if line.startswith('%global ') and '%{expand:' not in line:
                         rpm_globals.append(removeprefix(line, '%global '))
                     if line.startswith('%global upstream_version'):
                         upstream_version = run(


### PR DESCRIPTION

    error: Macro %platform_triplet_upstream has unterminated body