### PR TITLE
Remove the Patch 189 trailer with setuptools/pip version macros from Python 3.5

### DIFF
--- a/importpatches.py
+++ b/importpatches.py
@@ -124,7 +124,7 @@ def handle_patch(repo, commit_id, *, tempdir, python_version):
                 continue
             spec_comment.append(line)
 
-    if number == 189 and (python_version >= (3, 5) or python_version == (3,)):
+    if number == 189 and (python_version >= (3, 6) or python_version == (3,)):
         trailer = process_rpmwheels_patch(tempdir / path.name)
     else:
         trailer = ''


### PR DESCRIPTION
1. It is EOL, so the versions won't change.
2. We'll list the "second level" provides in the spec file,
   so having the 2 version macronized won't help.